### PR TITLE
Fix issue with wrong UV search

### DIFF
--- a/dissolve_fx/dissolve_fx.lua
+++ b/dissolve_fx/dissolve_fx.lua
@@ -28,7 +28,7 @@ function M.find_uvrect(sprite_url, image_id, scale_mode)
     local image_num
     for i, animation in ipairs(atlas_data.animations) do
         if animation.id == image_id then
-            image_num = i
+            image_num = animation.frame_start
             break
         end
     end


### PR DESCRIPTION
We can't be sure an index in `animations` corresponds to the index in `geometries`. It's not how runtime reads data. Runtime take `frame_start` as an index of the geometry: 

https://github.com/defold/defold/blob/c5849738616acbe30f380d8dfc1aa6d6e6970ab9/engine/gamesys/src/gamesys/components/comp_sprite.cpp#L1060-L1087

Fix https://github.com/indiesoftby/defold-dissolve-fx/issues/4